### PR TITLE
fix: respect snapshot protection flag in S3 Ceph backend

### DIFF
--- a/internal/s3pmoxcommon/s3pmoxcommon.go
+++ b/internal/s3pmoxcommon/s3pmoxcommon.go
@@ -65,6 +65,16 @@ func ListSnapshots(c minio.Client, datastore string, returnCorrupted bool) ([]Sn
 				corrupted:  false,
 			}
 
+			tags, err := S.ReadTags(c)
+			if err == nil {
+				if val, ok := tags["protected"]; ok && val == "true" {
+					S.Protected = true
+					s3backuplog.DebugPrint("Snapshot %s marked as protected (from tags)", S.S3Prefix())
+				}
+			} else {
+				s3backuplog.DebugPrint("Unable to get tags for %s: %s", S.S3Prefix(), err)
+			}
+
 			if len(path) == 3 {
 				S.Files = append(S.Files, SnapshotFile{
 					Filename:  path[2],

--- a/internal/s3pmoxcommon/s3pmoxcommon.go
+++ b/internal/s3pmoxcommon/s3pmoxcommon.go
@@ -66,13 +66,13 @@ func ListSnapshots(c minio.Client, datastore string, returnCorrupted bool) ([]Sn
 			}
 
 			tags, err := S.ReadTags(c)
-			if err == nil {
-				if val, ok := tags["protected"]; ok && val == "true" {
-					S.Protected = true
-					s3backuplog.DebugPrint("Snapshot %s marked as protected (from tags)", S.S3Prefix())
-				}
-			} else {
+			if err != nil {
 				s3backuplog.DebugPrint("Unable to get tags for %s: %s", S.S3Prefix(), err)
+			}
+			
+			if err == nil && tags["protected"] == "true" {
+			    S.Protected = true
+                s3backuplog.DebugPrint("Snapshot %s marked as protected (from tags)", S.S3Prefix())
 			}
 
 			if len(path) == 3 {


### PR DESCRIPTION
## Summary

This PR fixes a bug where protected backups were being deleted by the garbage collector due to incorrect tag handling.

---

## Problem

- The `.Protected` field in `Snapshot` was previously set using `object.UserTags["protected"]`.
- `ListObjects() with metadata` does **not** return actual S3 object tags on many backends (e.g. **Ceph**) - see related issue - https://github.com/tizbac/pmoxs3backuproxy/issues/64
- As a result, `Protected` remained unset on Ceph S3, and protected backups were not respected or preserved.

---

## Fix

- Introduced a call to `Snapshot.ReadTags()` immediately after creating each snapshot entry in `ListSnapshots()`.
- If the tag `protected=true` is present on `index.json.blob`, `.Protected` is now set correctly.

---

## Impact

- Garbage collector now correctly **preserves snapshots marked as protected on Ceph backend**.
- Ensures compatibility across **AWS S3**, **MinIO**, and **Ceph**-based backends.
- Improves snapshot lifecycle safety and reliability.

## To reproduce
Activate pmoxs3backuproxy on Ceph S3 backend and try to change backup protection status.
Before the fix - chaning protection status does not reflect
![Screenshot 2025-06-19 at 15 57 39](https://github.com/user-attachments/assets/943825f9-5379-4bc0-ae15-7000d2ebf005)

After the patch - chaing protection status does reflect
[
![Screenshot 2025-06-19 at 15 36 47](https://github.com/user-attachments/assets/08d4596f-fb53-4361-9d1d-c3b969011ffe)
](url)
```
2025/06/19 13:06:17.036324 [  INFO ] 1 snapshots in bucket
2025/06/19 13:06:17.036332 [  INFO ] Backup %!s(func() string=0x773600),32634/1745925605 is older than 7 but marked as protected, skip removal.
2025/06/19 13:06:17.036341 [  INFO ] Fetching object hashes
```