### PR TITLE
Optimize snapshot protection handling: move tag check from listing to deletion

### DIFF
--- a/cmd/garbagecollector/main.go
+++ b/cmd/garbagecollector/main.go
@@ -156,7 +156,9 @@ func main() {
 	s3backuplog.InfoPrint("%v snapshots in bucket", len(snapshots))
 	for _, s := range snapshots {
 		if s.BackupTime+(uint64(*retentionDays))*86400 < uint64(time.Now().Unix()) {
-			if s.Protected == true {
+			// Fetch S3 Ceph tags
+			tags, err := s.ReadTags(*minioClient)
+			if (err == nil && tags["protected"] == "true") || s.Protected {
 				s3backuplog.InfoPrint("Backup %s,%s/%d is older than %d but marked as protected, skip removal.",
 					s.S3Prefix,
 					s.BackupID,

--- a/internal/s3pmoxcommon/s3pmoxcommon.go
+++ b/internal/s3pmoxcommon/s3pmoxcommon.go
@@ -65,16 +65,6 @@ func ListSnapshots(c minio.Client, datastore string, returnCorrupted bool) ([]Sn
 				corrupted:  false,
 			}
 
-			tags, err := S.ReadTags(c)
-			if err != nil {
-				s3backuplog.DebugPrint("Unable to get tags for %s: %s", S.S3Prefix(), err)
-			}
-			
-			if err == nil && tags["protected"] == "true" {
-			    S.Protected = true
-                s3backuplog.DebugPrint("Snapshot %s marked as protected (from tags)", S.S3Prefix())
-			}
-
 			if len(path) == 3 {
 				S.Files = append(S.Files, SnapshotFile{
 					Filename:  path[2],


### PR DESCRIPTION
Optimize snapshot protection handling: move tag check from listing to deletion

Reverts: https://github.com/hostinger/pmoxs3backuproxy/pull/3
https://hostingers.atlassian.net/browse/VPS-3977
Tested:
```
Jun 20 09:09:56 us-phx-pve-node-dev4.hostinger.io start-garbagecollector.sh[4071559]: 2025/06/20 09:09:56 [  INFO ] Fetching snapshots
Jun 20 09:09:56 us-phx-pve-node-dev4.hostinger.io start-garbagecollector.sh[4071559]: 2025/06/20 09:09:56 [  INFO ] 2 snapshots in bucket
Jun 20 09:09:56 us-phx-pve-node-dev4.hostinger.io start-garbagecollector.sh[4071559]: 2025/06/20 09:09:56 [  INFO ] Backup %!s(func() string=0x7737c0),29231/1750410400 is older than 0 but marked as protected, skip removal.
Jun 20 09:09:56 us-phx-pve-node-dev4.hostinger.io start-garbagecollector.sh[4071559]: 2025/06/20 09:09:56 [  INFO ] Backup %!s(func() string=0x7737c0),31095/1750410048 is older than 0 but marked as protected, skip removal.
Jun 20 09:09:56 us-phx-pve-node-dev4.hostinger.io start-garbagecollector.sh[4071559]: 2025/06/20 09:09:56 [  INFO ] Fetching object hashes
```